### PR TITLE
Mat3: implement the get(i: int, j: int) method

### DIFF
--- a/lib/src/main/java/vmath/Mat3.java
+++ b/lib/src/main/java/vmath/Mat3.java
@@ -13,7 +13,7 @@ public class Mat3 {
 
     public float get(int i, int j) {
         if (i < 0 || i >= 3 || j >= 3 || j < 0) {
-            throw new IllegalArgumentException("Invalid indices");
+            throw new IndexOutOfBoundsException("Invalid indices");
         }
         return m[i * 3 + j];
     }

--- a/lib/src/main/java/vmath/Mat3.java
+++ b/lib/src/main/java/vmath/Mat3.java
@@ -12,7 +12,7 @@ public class Mat3 {
     }
 
     public float get(int i, int j) {
-        if (i < 0 || i >= 3 || j >= 3 || j < 0) {
+        if (i < 0 || i >= 3 || j < 0 || j >= 3) {
             throw new IndexOutOfBoundsException("Invalid indices");
         }
         return m[i * 3 + j];

--- a/lib/src/main/java/vmath/Mat3.java
+++ b/lib/src/main/java/vmath/Mat3.java
@@ -10,4 +10,11 @@ public class Mat3 {
             0.0f, 1.0f, 0.0f,
             0.0f, 0.0f, 1.0f};
     }
+
+    public float get(int i, int j) {
+        if (i < 0 || i >= 3 || j >= 3 || j < 0) {
+            throw new IllegalArgumentException("Invalid indices");
+        }
+        return m[i * 3 + j];
+    }
 }

--- a/lib/src/test/java/vmath/Mat3Test.java
+++ b/lib/src/test/java/vmath/Mat3Test.java
@@ -9,4 +9,29 @@ public class Mat3Test {
     void givenNoArgs_whenMat3Created_thenMatrixIsIdentity() {
         //TODO
     }
+
+    @Test
+    void givenIndices_whenGetCalled_thenReturnCorrectValue() {
+        var m1 = new Mat3();
+
+        assertEquals(1.0f, m1.get(0, 0));
+        assertEquals(0.0f, m1.get(0, 1));
+        assertEquals(0.0f, m1.get(0, 2));
+        assertEquals(0.0f, m1.get(1, 0));
+        assertEquals(1.0f, m1.get(1, 1));
+        assertEquals(0.0f, m1.get(1, 2));
+        assertEquals(0.0f, m1.get(2, 0));
+        assertEquals(0.0f, m1.get(2, 1));
+        assertEquals(1.0f, m1.get(2, 2));
+    }
+
+    @Test
+    void givenInvalidIndices_whenGetCalled_thenThrowIllegalArgumentException() {
+        var m1 = new Mat3();
+
+        assertThrows(IllegalArgumentException.class, () -> m1.get(-1, 0));
+        assertThrows(IllegalArgumentException.class, () -> m1.get(3, 0));
+        assertThrows(IllegalArgumentException.class, () -> m1.get(0, -1));
+        assertThrows(IllegalArgumentException.class, () -> m1.get(0, 3));
+    }
 }

--- a/lib/src/test/java/vmath/Mat3Test.java
+++ b/lib/src/test/java/vmath/Mat3Test.java
@@ -26,7 +26,7 @@ public class Mat3Test {
     }
 
     @Test
-    void givenInvalidIndices_whenGetCalled_thenThrowIllegalArgumentException() {
+    void givenInvalidIndices_whenGetCalled_thenThrowIndexOutOfBoundsException() {
         var m1 = new Mat3();
 
         assertThrows(IndexOutOfBoundsException.class, () -> m1.get(-1, 0));

--- a/lib/src/test/java/vmath/Mat3Test.java
+++ b/lib/src/test/java/vmath/Mat3Test.java
@@ -7,11 +7,6 @@ public class Mat3Test {
 
     @Test
     void givenNoArgs_whenMat3Created_thenMatrixIsIdentity() {
-        //TODO
-    }
-
-    @Test
-    void givenIndices_whenGetCalled_thenReturnCorrectValue() {
         var m1 = new Mat3();
 
         assertEquals(1.0f, m1.get(0, 0));
@@ -26,12 +21,17 @@ public class Mat3Test {
     }
 
     @Test
+    void givenIndices_whenGetCalled_thenReturnCorrectValue() {
+        //TODO
+    }
+
+    @Test
     void givenInvalidIndices_whenGetCalled_thenThrowIllegalArgumentException() {
         var m1 = new Mat3();
 
-        assertThrows(IllegalArgumentException.class, () -> m1.get(-1, 0));
-        assertThrows(IllegalArgumentException.class, () -> m1.get(3, 0));
-        assertThrows(IllegalArgumentException.class, () -> m1.get(0, -1));
-        assertThrows(IllegalArgumentException.class, () -> m1.get(0, 3));
+        assertThrows(IndexOutOfBoundsException.class, () -> m1.get(-1, 0));
+        assertThrows(IndexOutOfBoundsException.class, () -> m1.get(3, 0));
+        assertThrows(IndexOutOfBoundsException.class, () -> m1.get(0, -1));
+        assertThrows(IndexOutOfBoundsException.class, () -> m1.get(0, 3));
     }
 }


### PR DESCRIPTION
- [x] Create a test/s for a method `get()` that returns a matrix element at a specified `i` and `j` indices
- [x] Pass the test/s for the `get()` method
- [x] Finish the default constructor test with a ToDo
