### PR TITLE
Mat2: implement the get(i: int, j: int) method

### DIFF
--- a/lib/src/main/java/vmath/Mat2.java
+++ b/lib/src/main/java/vmath/Mat2.java
@@ -9,4 +9,15 @@ public class Mat2 {
             0.0f, 1.0f
         };
     }
+
+    public float get(int i, int j) {
+        
+        if (i < 0 || i >= 2 || j < 0 || j >= 2) {
+            throw new IndexOutOfBoundsException("Invalid indices");
+        }
+
+        int index = i * 2 + j;
+
+        return m[index];
+    }
 }

--- a/lib/src/main/java/vmath/Mat2.java
+++ b/lib/src/main/java/vmath/Mat2.java
@@ -15,8 +15,6 @@ public class Mat2 {
             throw new IndexOutOfBoundsException("Invalid indices");
         }
 
-        int index = i * 2 + j;
-
-        return m[index];
+        return m[i * 2 + j];
     }
 }

--- a/lib/src/main/java/vmath/Mat2.java
+++ b/lib/src/main/java/vmath/Mat2.java
@@ -11,7 +11,6 @@ public class Mat2 {
     }
 
     public float get(int i, int j) {
-        
         if (i < 0 || i >= 2 || j < 0 || j >= 2) {
             throw new IndexOutOfBoundsException("Invalid indices");
         }

--- a/lib/src/test/java/vmath/Mat2Test.java
+++ b/lib/src/test/java/vmath/Mat2Test.java
@@ -26,4 +26,19 @@ public class Mat2Test {
         assertEquals(0.0f, matrix.get(1, 0));
         assertEquals(1.0f, matrix.get(1, 1));
     }
+
+    @Test
+    void givenIndices_whenGetCalled_thenReturnValueMatches() {
+        //TODO
+    }
+
+    @Test
+    void givenInvalidIndices_whenGetCalled_thenThrowIllegalArgumentException() {
+        Mat2 matrix = new Mat2();
+
+        assertThrows(IndexOutOfBoundsException.class, () -> matrix.get(6, 1));
+        assertThrows(IndexOutOfBoundsException.class, () -> matrix.get(2, 1));
+        assertThrows(IndexOutOfBoundsException.class, () -> matrix.get(-1, 1));
+        assertThrows(IndexOutOfBoundsException.class, () -> matrix.get(-1, 13));
+    }
 }

--- a/lib/src/test/java/vmath/Mat2Test.java
+++ b/lib/src/test/java/vmath/Mat2Test.java
@@ -8,7 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class Mat2Test {
 
     @Test
-    public void givenNoArgs_whenMat2Created_thenMatrixIsIdentity() {
+    void givenNoArgs_whenMat2Created_thenMatrixIsIdentity() {
         Mat2 matrix = new Mat2();
 
         assertEquals(1.0f, matrix.get(0, 0));

--- a/lib/src/test/java/vmath/Mat2Test.java
+++ b/lib/src/test/java/vmath/Mat2Test.java
@@ -18,16 +18,6 @@ public class Mat2Test {
     }
 
     @Test
-    void givenIdentityMatrix_whenGetElement_thenReturnValueMatches() {
-        Mat2 matrix = new Mat2();
-
-        assertEquals(1.0f, matrix.get(0, 0));
-        assertEquals(0.0f, matrix.get(0, 1));
-        assertEquals(0.0f, matrix.get(1, 0));
-        assertEquals(1.0f, matrix.get(1, 1));
-    }
-
-    @Test
     void givenIndices_whenGetCalled_thenReturnValueMatches() {
         //TODO
     }

--- a/lib/src/test/java/vmath/Mat2Test.java
+++ b/lib/src/test/java/vmath/Mat2Test.java
@@ -26,9 +26,9 @@ public class Mat2Test {
     void givenInvalidIndices_whenGetCalled_thenThrowIndexOutOfBoundsException() {
         Mat2 matrix = new Mat2();
 
-        assertThrows(IndexOutOfBoundsException.class, () -> matrix.get(6, 1));
-        assertThrows(IndexOutOfBoundsException.class, () -> matrix.get(2, 1));
-        assertThrows(IndexOutOfBoundsException.class, () -> matrix.get(-1, 1));
-        assertThrows(IndexOutOfBoundsException.class, () -> matrix.get(-1, 13));
+        assertThrows(IndexOutOfBoundsException.class, () -> matrix.get(-1, 0));
+        assertThrows(IndexOutOfBoundsException.class, () -> matrix.get(3, 0));
+        assertThrows(IndexOutOfBoundsException.class, () -> matrix.get(0, -1));
+        assertThrows(IndexOutOfBoundsException.class, () -> matrix.get(0, 3));
     }
 }

--- a/lib/src/test/java/vmath/Mat2Test.java
+++ b/lib/src/test/java/vmath/Mat2Test.java
@@ -8,7 +8,22 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class Mat2Test {
 
     @Test
-    void givenNoArgs_whenMat2Created_thenMatrixIsIdentity() {
-        //TODO
+    public void givenNoArgs_whenMat2Created_thenMatrixIsIdentity() {
+        Mat2 matrix = new Mat2();
+
+        assertEquals(1.0f, matrix.get(0, 0));
+        assertEquals(0.0f, matrix.get(0, 1));
+        assertEquals(0.0f, matrix.get(1, 0));
+        assertEquals(1.0f, matrix.get(1, 1));
+    }
+
+    @Test
+    void givenIdentityMatrix_whenGetElement_thenReturnValueMatches() {
+        Mat2 matrix = new Mat2();
+
+        assertEquals(1.0f, matrix.get(0, 0));
+        assertEquals(0.0f, matrix.get(0, 1));
+        assertEquals(0.0f, matrix.get(1, 0));
+        assertEquals(1.0f, matrix.get(1, 1));
     }
 }

--- a/lib/src/test/java/vmath/Mat2Test.java
+++ b/lib/src/test/java/vmath/Mat2Test.java
@@ -23,7 +23,7 @@ public class Mat2Test {
     }
 
     @Test
-    void givenInvalidIndices_whenGetCalled_thenThrowIllegalArgumentException() {
+    void givenInvalidIndices_whenGetCalled_thenThrowIndexOutOfBoundsException() {
         Mat2 matrix = new Mat2();
 
         assertThrows(IndexOutOfBoundsException.class, () -> matrix.get(6, 1));


### PR DESCRIPTION
- [x] Create a test/s for a method `get()` that returns a matrix element at a specified `i` and `j` indices
- [x] Pass the test/s for the `get()` method
- [x] Finish the default constructor test with a ToDo